### PR TITLE
Bugfix in SmtpMessage constructor; now accepting "cc = null" as used in EmallClient.SendAsync

### DIFF
--- a/LightBuzz.SMTP/LightBuzz.SMTP/SmtpMessage.cs
+++ b/LightBuzz.SMTP/LightBuzz.SMTP/SmtpMessage.cs
@@ -154,7 +154,7 @@ namespace LightBuzz.SMTP
                 To.Add(to);
             }
 
-            if (!string.IsNullOrEmpty(cc.EmailAddress))
+            if (cc != null && !string.IsNullOrEmpty(cc.EmailAddress))
             {
                 Cc.Add(cc);
             }


### PR DESCRIPTION
Hi!
There is a small bug in your SmtpMessage constructor. If you pass "null" to the "cc" parameter, it will crash. This is for example used in your "EmailClient.SendAsync".
This pull request, just checks for "cc != null" and only in this case adds in the the "Cc" property.

I have used your project in an Windows 10 IoT device. I just need to made the classes internal and embed it into my project, because of some limitation of UWP on ARM. Thanks for your implementation!

Greetings and happy new year!
  Jochen
